### PR TITLE
Use '.@' at the end of the param, to pass effective path instead of the value

### DIFF
--- a/src/rule.js
+++ b/src/rule.js
@@ -19,6 +19,12 @@ import { concat, arrayOfArrays, getContextPath } from './utils'
 import { validateItem } from './validation'
 
 const defaultEnabler = [() => true],
+  FGP = ['FORX-GET-PATH'],
+  FGP_KEY = '__FORX_GET_PATH__',
+  // eslint-disable-next-line no-param-reassign
+  setFGPflag = (a) => { a[FGP_KEY] = FGP; return a },
+  hasFGPflag = a => a[FGP_KEY] === FGP,
+  getPathTo = v => setFGPflag(() => v),
   normalizeParams = (params) => {
     let result = params
     if (isFunction(result)) return normalizeParams(result())
@@ -58,12 +64,14 @@ const defaultEnabler = [() => true],
     return { ...rule, value, test, params, enabled }
   },
   queryPath = (value, context) => (p) => {
-    if (isFunction(p)) return p()
+    if (isFunction(p) && !hasFGPflag(p)) return p()
     const
       contextPath = getContextPath(p, context.indexes)
 
     if (last(contextPath) === '@') {
       return slice(0, contextPath.length - 1, contextPath)
+    } else if (hasFGPflag(p)) {
+      return contextPath
     }
     return traverse(contextPath, value)
   },
@@ -110,7 +118,7 @@ const defaultEnabler = [() => true],
         resPath =
           (rule.to && getContextPath(rule.to, context.indexes)) || context.goal
       if (!isEnabled(ruleParams, rule.enabled)) return []
-      // eslint-disable-next-line
+      // eslint-disable-next-line one-var
       const errors = map(r => r.value, validateItem([ruleParams, rule.test]))
       if (!isEmpty(errors)) res = set(resPath, errors, res)
       return null
@@ -127,4 +135,4 @@ const defaultEnabler = [() => true],
   }
 
 export default runRule
-export { runRule, normalizeRule, makeConfig, runRaw, run }
+export { runRule, normalizeRule, makeConfig, runRaw, run, getPathTo }

--- a/src/rule.js
+++ b/src/rule.js
@@ -19,12 +19,6 @@ import { concat, arrayOfArrays, getContextPath } from './utils'
 import { validateItem } from './validation'
 
 const defaultEnabler = [() => true],
-  FGP = ['FORX-GET-PATH'],
-  FGP_KEY = '__FORX_GET_PATH__',
-  // eslint-disable-next-line no-param-reassign
-  setFGPflag = (a) => { a[FGP_KEY] = FGP; return a },
-  hasFGPflag = a => a[FGP_KEY] === FGP,
-  getPathTo = v => setFGPflag(() => v),
   normalizeParams = (params) => {
     let result = params
     if (isFunction(result)) return normalizeParams(result())
@@ -64,14 +58,12 @@ const defaultEnabler = [() => true],
     return { ...rule, value, test, params, enabled }
   },
   queryPath = (value, context) => (p) => {
-    if (isFunction(p) && !hasFGPflag(p)) return p()
+    if (isFunction(p)) return p()
     const
       contextPath = getContextPath(p, context.indexes)
 
     if (last(contextPath) === '@') {
       return slice(0, contextPath.length - 1, contextPath)
-    } else if (hasFGPflag(p)) {
-      return contextPath
     }
     return traverse(contextPath, value)
   },
@@ -118,7 +110,7 @@ const defaultEnabler = [() => true],
         resPath =
           (rule.to && getContextPath(rule.to, context.indexes)) || context.goal
       if (!isEnabled(ruleParams, rule.enabled)) return []
-      // eslint-disable-next-line one-var
+      // eslint-disable-next-line
       const errors = map(r => r.value, validateItem([ruleParams, rule.test]))
       if (!isEmpty(errors)) res = set(resPath, errors, res)
       return null
@@ -135,4 +127,4 @@ const defaultEnabler = [() => true],
   }
 
 export default runRule
-export { runRule, normalizeRule, makeConfig, runRaw, run, getPathTo }
+export { runRule, normalizeRule, makeConfig, runRaw, run }

--- a/src/rule.js
+++ b/src/rule.js
@@ -12,7 +12,8 @@ import {
   isEmpty,
   forEach,
   last,
-  slice
+  slice,
+  cloneDeep
 } from 'lodash/fp'
 import { isExisty } from './assert'
 import { concat, arrayOfArrays, getContextPath } from './utils'
@@ -58,7 +59,12 @@ const defaultEnabler = [() => true],
     return { ...rule, value, test, params, enabled }
   },
   queryPath = (value, context) => (p) => {
-    if (isFunction(p)) return p()
+    if (isFunction(p)) {
+      return p(
+        // this is to prevent anyone from messing with lib internals
+        cloneDeep({ current: context.current, indexes: context.indexes })
+      )
+    }
     const
       contextPath = getContextPath(p, context.indexes)
 
@@ -110,7 +116,7 @@ const defaultEnabler = [() => true],
         resPath =
           (rule.to && getContextPath(rule.to, context.indexes)) || context.goal
       if (!isEnabled(ruleParams, rule.enabled)) return []
-      // eslint-disable-next-line
+      // eslint-disable-next-line one-var
       const errors = map(r => r.value, validateItem([ruleParams, rule.test]))
       if (!isEmpty(errors)) res = set(resPath, errors, res)
       return null

--- a/src/rule.js
+++ b/src/rule.js
@@ -10,7 +10,9 @@ import {
   isArray,
   isObject,
   isEmpty,
-  forEach
+  forEach,
+  last,
+  slice
 } from 'lodash/fp'
 import { isExisty } from './assert'
 import { concat, arrayOfArrays, getContextPath } from './utils'
@@ -57,7 +59,13 @@ const defaultEnabler = [() => true],
   },
   queryPath = (value, context) => (p) => {
     if (isFunction(p)) return p()
-    return traverse(getContextPath(p, context.indexes), value)
+    const
+      contextPath = getContextPath(p, context.indexes)
+
+    if (last(contextPath) === '@') {
+      return slice(0, contextPath.length - 1, contextPath)
+    }
+    return traverse(contextPath, value)
   },
   queryPaths = (params, value, context) =>
     map(queryPath(value, context), params),

--- a/src/rule.js
+++ b/src/rule.js
@@ -60,10 +60,11 @@ const defaultEnabler = [() => true],
   },
   queryPath = (value, context) => (p) => {
     if (isFunction(p)) {
-      return p(
-        // this is to prevent anyone from messing with lib internals
-        cloneDeep({ current: context.current, indexes: context.indexes })
-      )
+      // clone to prevent anyone from messing with lib internals
+      return p(cloneDeep({
+        current: context.current,
+        indexes: context.indexes
+      }))
     }
     const
       contextPath = getContextPath(p, context.indexes)

--- a/test/rule.spec.js
+++ b/test/rule.spec.js
@@ -1,5 +1,5 @@
 import { map, cloneDeep } from 'lodash/fp'
-import { runRule, normalizeRule, run, makeConfig } from '../src/rule'
+import { runRule, normalizeRule, run, makeConfig, getPathTo } from '../src/rule'
 import { config, value } from './rule/test-config'
 
 const runNormalizedRule = (rule, val) => runRule(normalizeRule(rule), val)
@@ -116,18 +116,29 @@ describe('rule', () => {
     const
       successMap = {
         'L.1.1': ['team', '0', 'address', '0'],
-        'L.2.1': ['team', '1', 'address', '0']
+        'L.2.1': ['team', '1', 'address', '0'],
+        'L.2.2': ['team', '1', 'address', '1']
       },
       rule = {
       // -1
         value: 'team.address.line1',
         params: [
           'team.{team}.address.{address}.line1',
-          'team.{team}.address.{address}.@'
+          'team.{team}.address.{address}.@',
+          getPathTo('team.{team}.address.{address}'),
+          getPathTo(['team', '{team}', 'address', '{address}']),
+          getPathTo('team.{team}.address'),
+          'team.{team}.address.@'
+          // pathTo('team.{team}.address.{address}')
         ],
         test: [
-          [(v, p1, p2) => {
+          [(v, ...params) => {
+            const [p1, p2, p3, p4, p5, p6] = params
             expect(successMap[p1]).toEqual(p2)
+            expect(successMap[p1]).toEqual(p3)
+            expect(successMap[p1]).toEqual(p4)
+            expect(successMap[p1].slice(0, 3)).toEqual(p5)
+            expect(successMap[p1].slice(0, 3)).toEqual(p6)
             return true
           }, 'ERR']
         ]
@@ -141,7 +152,8 @@ describe('rule', () => {
           },
           {
             address: [
-              { line1: 'L.2.1' }
+              { line1: 'L.2.1' },
+              { line1: 'L.2.2' }
             ]
           }
         ]

--- a/test/rule.spec.js
+++ b/test/rule.spec.js
@@ -148,7 +148,5 @@ describe('rule', () => {
       }
 
     runNormalizedRule(rule, valForTest)
-
-    expect(true).toEqual(true)
   })
 })

--- a/test/rule.spec.js
+++ b/test/rule.spec.js
@@ -1,5 +1,5 @@
 import { map, cloneDeep } from 'lodash/fp'
-import { runRule, normalizeRule, run, makeConfig, getPathTo } from '../src/rule'
+import { runRule, normalizeRule, run, makeConfig } from '../src/rule'
 import { config, value } from './rule/test-config'
 
 const runNormalizedRule = (rule, val) => runRule(normalizeRule(rule), val)

--- a/test/rule.spec.js
+++ b/test/rule.spec.js
@@ -1,5 +1,5 @@
 import { map, cloneDeep } from 'lodash/fp'
-import { runRule, normalizeRule, run, makeConfig, getPathTo } from '../src/rule'
+import { runRule, normalizeRule, run, makeConfig } from '../src/rule'
 import { config, value } from './rule/test-config'
 
 const runNormalizedRule = (rule, val) => runRule(normalizeRule(rule), val)
@@ -116,29 +116,18 @@ describe('rule', () => {
     const
       successMap = {
         'L.1.1': ['team', '0', 'address', '0'],
-        'L.2.1': ['team', '1', 'address', '0'],
-        'L.2.2': ['team', '1', 'address', '1']
+        'L.2.1': ['team', '1', 'address', '0']
       },
       rule = {
       // -1
         value: 'team.address.line1',
         params: [
           'team.{team}.address.{address}.line1',
-          'team.{team}.address.{address}.@',
-          getPathTo('team.{team}.address.{address}'),
-          getPathTo(['team', '{team}', 'address', '{address}']),
-          getPathTo('team.{team}.address'),
-          'team.{team}.address.@'
-          // pathTo('team.{team}.address.{address}')
+          'team.{team}.address.{address}.@'
         ],
         test: [
-          [(v, ...params) => {
-            const [p1, p2, p3, p4, p5, p6] = params
+          [(v, p1, p2) => {
             expect(successMap[p1]).toEqual(p2)
-            expect(successMap[p1]).toEqual(p3)
-            expect(successMap[p1]).toEqual(p4)
-            expect(successMap[p1].slice(0, 3)).toEqual(p5)
-            expect(successMap[p1].slice(0, 3)).toEqual(p6)
             return true
           }, 'ERR']
         ]
@@ -152,8 +141,7 @@ describe('rule', () => {
           },
           {
             address: [
-              { line1: 'L.2.1' },
-              { line1: 'L.2.2' }
+              { line1: 'L.2.1' }
             ]
           }
         ]

--- a/test/rule.spec.js
+++ b/test/rule.spec.js
@@ -111,4 +111,44 @@ describe('rule', () => {
       team: [undefined, undefined, { customName: ['empty'], name: ['empty'] }]
     })
   })
+
+  it('provides path to the processed value', () => {
+    const
+      successMap = {
+        'L.1.1': ['team', '0', 'address', '0'],
+        'L.2.1': ['team', '1', 'address', '0']
+      },
+      rule = {
+      // -1
+        value: 'team.address.line1',
+        params: [
+          'team.{team}.address.{address}.line1',
+          'team.{team}.address.{address}.@'
+        ],
+        test: [
+          [(v, p1, p2) => {
+            expect(successMap[p1]).toEqual(p2 || p1)
+            return true
+          }, 'ERR']
+        ]
+      },
+      valForTest = {
+        team: [
+          {
+            address: [
+              { line1: 'L.1.1' }
+            ]
+          },
+          {
+            address: [
+              { line1: 'L.2.1' }
+            ]
+          }
+        ]
+      }
+
+    runNormalizedRule(rule, valForTest)
+
+    expect(true).toEqual(true)
+  })
 })

--- a/test/rule.spec.js
+++ b/test/rule.spec.js
@@ -1,5 +1,5 @@
 import { map, cloneDeep } from 'lodash/fp'
-import { runRule, normalizeRule, run, makeConfig } from '../src/rule'
+import { runRule, normalizeRule, run, makeConfig, getPathTo } from '../src/rule'
 import { config, value } from './rule/test-config'
 
 const runNormalizedRule = (rule, val) => runRule(normalizeRule(rule), val)
@@ -114,20 +114,35 @@ describe('rule', () => {
 
   it('provides path to the processed value', () => {
     const
-      successMap = {
+      successMap2 = {
         'L.1.1': ['team', '0', 'address', '0'],
-        'L.2.1': ['team', '1', 'address', '0']
+        'L.2.1': ['team', '1', 'address', '0'],
+        'L.2.2': ['team', '1', 'address', '1']
+      },
+      successMap3 = {
+        'L.1.1': ['team', 0, 'address', 0, 'line1'],
+        'L.2.1': ['team', 1, 'address', 0, 'line1'],
+        'L.2.2': ['team', 1, 'address', 1, 'line1']
+      },
+      successMap3b = {
+        'L.1.1': { team: 0, address: 0 },
+        'L.2.1': { team: 1, address: 0 },
+        'L.2.2': { team: 1, address: 1 }
       },
       rule = {
       // -1
         value: 'team.address.line1',
         params: [
           'team.{team}.address.{address}.line1',
-          'team.{team}.address.{address}.@'
+          'team.{team}.address.{address}.@',
+          a => a
         ],
         test: [
-          [(v, p1, p2) => {
-            expect(successMap[p1]).toEqual(p2)
+          [(v, ...params) => {
+            const [p1, p2, p3] = params
+            expect(successMap2[p1]).toEqual(p2)
+            expect(successMap3[p1]).toEqual(p3.current)
+            expect(successMap3b[p1]).toEqual(p3.indexes)
             return true
           }, 'ERR']
         ]
@@ -141,7 +156,8 @@ describe('rule', () => {
           },
           {
             address: [
-              { line1: 'L.2.1' }
+              { line1: 'L.2.1' },
+              { line1: 'L.2.2' }
             ]
           }
         ]

--- a/test/rule.spec.js
+++ b/test/rule.spec.js
@@ -127,7 +127,7 @@ describe('rule', () => {
         ],
         test: [
           [(v, p1, p2) => {
-            expect(successMap[p1]).toEqual(p2 || p1)
+            expect(successMap[p1]).toEqual(p2)
             return true
           }, 'ERR']
         ]


### PR DESCRIPTION
This is something I was thinking of.

Such a path specification received as a param would make some things a lot easier.